### PR TITLE
feat: extend the deploy submodule

### DIFF
--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -31,15 +31,46 @@ locals {
   appspec_content = replace(jsonencode(local.appspec), "\"", "\\\"")
   appspec_sha256  = sha256(jsonencode(local.appspec))
 
+  appspec_rollback = merge({
+    version = "0.0"
+    Resources = [
+      {
+        MyFunction = {
+          Type = "AWS::Lambda::Function"
+          Properties = {
+            Name           = var.function_name
+            Alias          = var.alias_name
+            CurrentVersion = var.target_version
+            TargetVersion  = var.current_version != "" ? var.current_version : local.current_version
+          }
+        }
+      }
+    ]
+    }, var.before_allow_traffic_hook_arn != "" || var.after_allow_traffic_hook_arn != "" ? {
+    Hooks = [for k, v in zipmap(["BeforeAllowTraffic", "AfterAllowTraffic"], [
+      var.before_allow_traffic_hook_arn != "" ? var.before_allow_traffic_hook_arn : null,
+      var.after_allow_traffic_hook_arn != "" ? var.after_allow_traffic_hook_arn : null
+    ]) : map(k, v) if v != null]
+  } : {})
+
+  appspec_rollback_content = replace(jsonencode(local.appspec_rollback), "\"", "\\\"")
+  appspec_rollback_sha256  = sha256(jsonencode(local.appspec_rollback))
+
   script = <<EOF
 #!/bin/bash
 
 if [ '${var.target_version}' == '${var.current_version != "" ? var.current_version : local.current_version}' ]; then
-  echo "Skipping deployment because target version (${var.target_version}) is already the current version"
+  echo "Skipping deployment because target & current versions are identical (Version: ${var.target_version})"
   exit 0
 fi
 
-ID=$(${var.aws_cli_command} deploy create-deployment \
+if [ -z "$ROLLBACK" ] || [ -z "$WAIT_DEPLOYMENT_COMPLETION" ]; then
+  echo "Please set ROLLBACK & WAIT_DEPLOYMENT_COMPLETION Environment Variables"
+  exit 1
+fi
+
+if [ $ROLLBACK = false ]; then
+  ID=$(${var.aws_cli_command} deploy create-deployment \
     --application-name ${local.app_name} \
     --deployment-group-name ${local.deployment_group_name} \
     --deployment-config-name ${var.deployment_config_name} \
@@ -47,38 +78,45 @@ ID=$(${var.aws_cli_command} deploy create-deployment \
     --revision '{"revisionType": "AppSpecContent", "appSpecContent": {"content": "${local.appspec_content}", "sha256": "${local.appspec_sha256}"}}' \
     --output text \
     --query '[deploymentId]')
+else
+  echo "Running Deployment Rollback"
+  ID=$(${var.aws_cli_command} deploy create-deployment \
+    --application-name ${local.app_name} \
+    --deployment-group-name ${local.deployment_group_name} \
+    --deployment-config-name ${var.rollback_deployment_config_name} \
+    --description "${var.description}" \
+    --revision '{"revisionType": "AppSpecContent", "appSpecContent": {"content": "${local.appspec_rollback_content}", "sha256": "${local.appspec_rollback_sha256}"}}' \
+    --output text \
+    --query '[deploymentId]')
+fi
 
-%{if var.wait_deployment_completion}
-STATUS=$(${var.aws_cli_command} deploy get-deployment \
+if [ $WAIT_DEPLOYMENT_COMPLETION = true ]; then
+  STATUS=$(${var.aws_cli_command} deploy get-deployment \
     --deployment-id $ID \
     --output text \
     --query '[deploymentInfo.status]')
 
-while [ $STATUS == "Created" ] || [ $STATUS == "InProgress" ] || [ $STATUS == "Pending" ] || [ $STATUS == "Queued" ] || [ $STATUS == "Ready" ]; do
+  while [ $STATUS == "Created" ] || [ $STATUS == "InProgress" ] || [ $STATUS == "Pending" ] || [ $STATUS == "Queued" ] || [ $STATUS == "Ready" ]; do
     echo "Status: $STATUS..."
     STATUS=$(${var.aws_cli_command} deploy get-deployment \
-        --deployment-id $ID \
-        --output text \
-        --query '[deploymentInfo.status]')
+      --deployment-id $ID \
+      --output text \
+      --query '[deploymentInfo.status]')
     sleep 5
-done
+  done
 
-if [ $STATUS == "Succeeded" ]; then
+  if [ $STATUS == "Succeeded" ]; then
     echo "Deployment succeeded."
-else
+  else
     echo "Deployment failed!"
+  fi
+  ${var.aws_cli_command} deploy get-deployment --deployment-id $ID
+else
+  echo "Deployment started, but wait deployment completion is disabled!"
+  ${var.aws_cli_command} deploy get-deployment --deployment-id $ID
 fi
 
-${var.aws_cli_command} deploy get-deployment --deployment-id $ID
-
-%{else}
-
-echo "Deployment started, but wait deployment completion is disabled!"
-${var.aws_cli_command} deploy get-deployment --deployment-id $ID
-
-%{endif}
 EOF
-
 }
 
 data "aws_lambda_alias" "this" {
@@ -98,9 +136,9 @@ data "aws_lambda_function" "this" {
 resource "local_file" "deploy_script" {
   count = var.create && var.create_deployment && var.save_deploy_script ? 1 : 0
 
-  filename             = "deploy_script_${local.appspec_sha256}.txt"
+  filename             = "deploy_script_${local.appspec_sha256}.sh"
   directory_permission = "0755"
-  file_permission      = "0644"
+  file_permission      = "0755"
   content              = local.script
 }
 
@@ -114,19 +152,23 @@ resource "null_resource" "deploy" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command = local.script
+    command     = local.script
+    environment = {
+      WAIT_DEPLOYMENT_COMPLETION = var.wait_deployment_completion
+      ROLLBACK                   = false
+    }
   }
 }
 
 resource "aws_codedeploy_app" "this" {
-  count = var.create && var.create_app && !var.use_existing_app ? 1 : 0
+  count = var.create && var.create_app && ! var.use_existing_app ? 1 : 0
 
   name             = var.app_name
   compute_platform = "Lambda"
 }
 
 resource "aws_codedeploy_deployment_group" "this" {
-  count = var.create && var.create_deployment_group && !var.use_existing_deployment_group ? 1 : 0
+  count = var.create && var.create_deployment_group && ! var.use_existing_deployment_group ? 1 : 0
 
   app_name               = local.app_name
   deployment_group_name  = var.deployment_group_name
@@ -165,7 +207,7 @@ resource "aws_codedeploy_deployment_group" "this" {
 }
 
 data "aws_iam_role" "codedeploy" {
-  count = var.create && !var.create_codedeploy_role ? 1 : 0
+  count = var.create && ! var.create_codedeploy_role ? 1 : 0
 
   name = var.codedeploy_role_name
 }

--- a/modules/deploy/outputs.tf
+++ b/modules/deploy/outputs.tf
@@ -33,6 +33,21 @@ output "appspec_sha256" {
   value       = local.appspec_sha256
 }
 
+output "appspec_rollback" {
+  description = "Appspec data as HCL"
+  value       = local.appspec_rollback
+}
+
+output "appspec_rollback_content" {
+  description = "Appspec data as valid JSON"
+  value       = local.appspec_rollback_content
+}
+
+output "appspec_rollback_sha256" {
+  description = "SHA256 of Appspec JSON"
+  value       = local.appspec_rollback_sha256
+}
+
 output "script" {
   description = "Deployment script"
   value       = local.script

--- a/modules/deploy/variables.tf
+++ b/modules/deploy/variables.tf
@@ -96,6 +96,12 @@ variable "deployment_config_name" {
   default     = "CodeDeployDefault.LambdaAllAtOnce"
 }
 
+variable "rollback_deployment_config_name" {
+  description = "Name of deployment config to use"
+  type        = string
+  default     = "CodeDeployDefault.LambdaAllAtOnce"
+}
+
 variable "auto_rollback_enabled" {
   description = "Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group."
   type        = bool


### PR DESCRIPTION
The deploy submodule, generates as bash script
that supports rolling back to the previous lambda function version.

In order to run the bash script,
the user must set the enviroment variables (bool)
ROLLBACK & WAIT_DEPLOYMENT_COMPLETION.